### PR TITLE
feat: #WB2-916, add new icons css with good color

### DIFF
--- a/scss/variables/_icons.scss
+++ b/scss/variables/_icons.scss
@@ -101,6 +101,10 @@ $icons-applications: (
     "color": $yellow,
     "glyph": "\e81a",
   ),
+  "agenda": (
+    "color": $yellow,
+    "glyph": "\e966",
+  ),
   "archive": (
     "color": $yellow,
     "glyph": "\e81d",
@@ -119,11 +123,11 @@ $icons-applications: (
   ),
   "cahier-textes": (
     "color": $green,
-    "glyph": "\e86f",
+    "glyph": "\e965",
   ),
   "calendar": (
     "color": $yellow,
-    "glyph": "\e834",
+    "glyph": "\e966",
   ),
   "canal-numerique": (
     "color": $blue,
@@ -160,6 +164,10 @@ $icons-applications: (
   "directory": (
     "color": $green,
     "glyph": "\e811",
+  ),
+  "edt": (
+    "color": $blue,
+    "glyph": "\e964",
   ),
   "exercizer": (
     "color": $purple,


### PR DESCRIPTION
Changements : 

Ajout des glyph + color sur les icones : competence, emploi du temp, agenda et cahier de texte. 

Ticket: 
#WB2-916
https://edifice-community.atlassian.net/jira/software/c/projects/WB2/boards/41?modal=detail&selectedIssue=WB2-916&assignee=712020%3A10bcae25-bc57-4d87-bad7-d00cf4320f32